### PR TITLE
Week4

### DIFF
--- a/src/camera_utils.py
+++ b/src/camera_utils.py
@@ -36,7 +36,7 @@ def project_world_point_to_image(camera: Camera, world_point: np.ndarray) -> np.
     Y = world_point[1]
     Z = world_point[2]    
 
-    u = camera.fx*(X/Z) + camera.cx #the cx/cy is the intrinsic parameter (offset)
+    u = camera.fx*(X/Z) + camera.cx #the cx/cy is the intrinsic parameter (offset) of camera placement
     v = camera.fy*(Y/Z) + camera.cy
 
     pixel_coords = np.array([u, v])

--- a/src/plan_computation.py
+++ b/src/plan_computation.py
@@ -22,7 +22,12 @@ def compute_distance_between_images(
     Returns:
         The horizontal and vertical distance between images (as a 2-element array).
     """
-    raise NotImplementedError()
+    
+    footprint_x, footprint_y = compute_image_footprint_on_surface(camera, dataset_spec.height)
+    horizontal_distance = footprint_x - (dataset_spec.sidelap * footprint_x)
+    vertical_distance = footprint_y - (dataset_spec.overlap * footprint_y)
+
+    return np.array([horizontal_distance, vertical_distance])
 
 
 def compute_speed_during_photo_capture(


### PR DESCRIPTION
Implemented the compute_distance_between-images function in the plan_computation.py file by utilizing footprints in the x and y direction, as well as overlap and sidelap. As the overlap/sidelap is a ratio that is provided, we can compute the overlap/sidelpa distance by multiplying the ratio by the corresponding footprints in the x and y direction. Subtracting the found overlap/sidelap distance from footprints in x and y yields the horizontal and vertical image distance. 